### PR TITLE
chore(deps): pin typescript to <7 until peer ranges allow it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "typescript-eslint and ts-jest don't accept TS 7 in their peer ranges yet",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
+}


### PR DESCRIPTION
TS 7 can't install: `@typescript-eslint/parser@8.65.0` peers `typescript >=4.8.4 <6.1.0` and `ts-jest@29.4.12` peers `typescript >=4.3 <7`. Renovate keeps proposing it (#29), so this caps it at <7 until both ship support.

Also pulls in `config:recommended` explicitly, since the repo had no renovate config file.