### PR TITLE
chore(deps): tighten the typescript pin to <6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,9 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
-      "description": "typescript-eslint and ts-jest don't accept TS 7 in their peer ranges yet",
+      "description": "TS 6 needs an explicit types array and a move off moduleResolution node10",
       "matchPackageNames": ["typescript"],
-      "allowedVersions": "<7"
+      "allowedVersions": "<6"
     }
   ]
 }


### PR DESCRIPTION
TS 6 needs `types` set explicitly, since the tests stop seeing the jest and node globals, plus a move off `moduleResolution: node`, which TS 6 deprecates and TS 7 removes. This keeps the repo on TS 5 until both are done.

Replaces the `<7` cap from #31, which only moved renovate from proposing v7 to proposing v6 (#32).