### PR TITLE
chore(deps): move to typescript 6 and loosen the pin to <6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/parser": "^8.65.0",
     "auto-changelog": "^2.6.0",
     "eslint": "^10.8.0",
@@ -52,7 +53,7 @@
     "rimraf": "^6.1.3",
     "safe-publish-latest": "^2.0.0",
     "ts-jest": "^29.4.12",
-    "typescript": "^5.0.4"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9 || ^10"

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,9 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
-      "description": "TS 6 needs an explicit types array and a move off moduleResolution node10",
+      "description": "@typescript-eslint/parser peers typescript >=4.8.4 <6.1.0, and ts-jest peers >=4.3 <7. Raise this once both widen.",
       "matchPackageNames": ["typescript"],
-      "allowedVersions": "<6"
+      "allowedVersions": "<6.1"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "lib": ["ES2020"],
-    "outDir": "dist",
+    "types": ["node", "jest"],
+    "outDir": "lib",
     "rootDir": "src"
   },
   "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx"]


### PR DESCRIPTION
`moduleResolution: node` is what forced the pin down to `<6`. TS 6 errors on it (TS5107) and TS 7 removed it (TS5108). Deleting the line handles both, since `module: commonjs` already resolves that way by default, and src compiles clean on 5.9.3, 6.0.3 and 7.0.2 without it.

The other half of #34 was the types array. TS 6 stopped picking up `@types/*` that aren't direct dependencies, so `require` and `module` went untyped and the test files lost the jest globals. It's explicit now, and `@types/node` is a real devDependency instead of something jest happened to hoist. `outDir` also points at `lib` now, which the build was already passing on the command line.

`@typescript-eslint/parser@8.65.0` peers `typescript >=4.8.4 <6.1.0` and `ts-jest@29.4.12` peers `>=4.3 <7`, so the pin is `<6.1` and renovate's description now names both packages to check before raising it.

TS 6 changes `lib/`: both emitted files pick up a `"use strict"` prologue. Same behaviour, the modules were already strict-safe, but main and npm are out of sync until the next release.

## Proof

Lint, all 34 tests and the build on TS 6.0.3, plus the emitted diff against what v1.2.0 shipped:

![lint, tests and build passing on TypeScript 6.0.3, and the emitted lib diff against v1.2.0](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-typescript-6/safe-jsx-typescript-6/proof-ts6-typescript6.png)

