### PR TITLE
fix(jsx-explicit-boolean): five soundness bugs in the boolean check

### DIFF
--- a/src/rules/jsx-explicit-boolean.test.tsx
+++ b/src/rules/jsx-explicit-boolean.test.tsx
@@ -55,6 +55,11 @@ ruleTester.run("jsx-explicit-boolean", require("./jsx-explicit-boolean"), {
     {
       code: "{!!step.subtitle && index === activeStep - 1 && <Text />}",
     },
+
+    // The same variable twice: the cycle guard tracks the resolution path, so
+    // seeing `a` on the left must not poison `a` on the right.
+    { code: "const a = true; (a && a) && <div />;" },
+    { code: "const a = true; a && <>{a}</>;" },
   ],
   invalid: [
     // Conditional expressions
@@ -135,6 +140,76 @@ ruleTester.run("jsx-explicit-boolean", require("./jsx-explicit-boolean"), {
       code: "const a = 0 + 0; a && <div />;",
       errors: [{ messageId: "booleanConversion" }],
       output: "const a = 0 + 0; Boolean(a) && <div />;",
+    },
+
+    // Declarations with no initialiser. These used to crash the rule while
+    // reading `type` off a null init, which takes the whole lint run down.
+    {
+      code: "let a; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "let a; Boolean(a) && <div />;",
+    },
+    {
+      code: "for (const x of xs) { x && <div />; }",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "for (const x of xs) { Boolean(x) && <div />; }",
+    },
+    {
+      code: "for (const k in o) { k && <div />; }",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "for (const k in o) { Boolean(k) && <div />; }",
+    },
+
+    // A declaration that refers to itself. This used to recurse until the stack
+    // ran out.
+    {
+      code: "var a = a; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "var a = a; Boolean(a) && <div />;",
+    },
+
+    // Reassignment. The initialiser says boolean, the value at the use site is
+    // 0, and the old rule trusted the initialiser and stayed quiet.
+    {
+      code: "let a = true; a = 0; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "let a = true; a = 0; Boolean(a) && <div />;",
+    },
+    {
+      code: "let a = true; const b = a; a = 0; b && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "let a = true; const b = a; a = 0; Boolean(b) && <div />;",
+    },
+
+    // Fragments render the falsy left-hand value just like elements do, and
+    // used to be skipped entirely.
+    {
+      code: "const a = 0; a && <></>;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "const a = 0; Boolean(a) && <></>;",
+    },
+    {
+      code: "const Component = ({ a }) => <View>{a && <>{a}</>}</View>;",
+      errors: [{ messageId: "booleanConversion" }],
+      output:
+        "const Component = ({ a }) => <View>{Boolean(a) && <>{a}</>}</View>;",
+    },
+
+    // A comma expression needs its own parentheses, otherwise the fix turns
+    // into Boolean(a, b) and quietly evaluates a instead of b.
+    {
+      code: "const a = 0, b = 1; (a, b) && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "const a = 0, b = 1; (Boolean((a, b))) && <div />;",
+    },
+
+    // The initialiser resolves from the declaration site, so a shadowing
+    // binding at the use site can't vouch for it.
+    {
+      code: "const a = t; const Component = () => { const t = true; return a && <div />; };",
+      errors: [{ messageId: "booleanConversion" }],
+      output:
+        "const a = t; const Component = () => { const t = true; return Boolean(a) && <div />; };",
     },
   ],
 });

--- a/src/rules/jsx-explicit-boolean.ts
+++ b/src/rules/jsx-explicit-boolean.ts
@@ -15,7 +15,13 @@ function findVariable(initialScope, nodeName) {
   return null;
 }
 
-function checkBooleanValidity(node, scope) {
+// `seen` holds the variables on the current resolution path, so a declaration
+// that refers back to itself stops instead of recursing forever.
+function checkBooleanValidity(node, scope, seen = new Set()) {
+  // A declaration can have no initialiser at all: `let a;`, or the binding in
+  // `for (const x of xs)`. Both give a null init.
+  if (!node) return false;
+
   const { type } = node;
 
   switch (type) {
@@ -45,26 +51,48 @@ function checkBooleanValidity(node, scope) {
       if (operator !== "&&") return false;
 
       return (
-        checkBooleanValidity(left, scope) && checkBooleanValidity(right, scope)
+        checkBooleanValidity(left, scope, seen) &&
+        checkBooleanValidity(right, scope, seen)
       );
     }
 
     // Example: a ? b : c, where both b and c are boolean
     case "ConditionalExpression":
       return (
-        checkBooleanValidity(node.test, scope) &&
-        checkBooleanValidity(node.consequent, scope) &&
-        checkBooleanValidity(node.alternate, scope)
+        checkBooleanValidity(node.test, scope, seen) &&
+        checkBooleanValidity(node.consequent, scope, seen) &&
+        checkBooleanValidity(node.alternate, scope, seen)
       );
 
     case "Identifier": {
       const variable = findVariable(scope, node.name);
       if (!variable) return false;
 
+      // `var a = a;` resolves to itself, so bail before following it again.
+      if (seen.has(variable)) return false;
+
       const variableDef = variable.defs.find((def) => def.type === "Variable");
       if (!variableDef) return false;
 
-      return checkBooleanValidity(variableDef.node.init, scope);
+      // Any write after the declaration makes the initialiser useless as
+      // evidence: `let a = true; a = 0;` isn't a boolean by the time it's used.
+      const isReassigned = variable.references.some(
+        (reference) => reference.isWrite() && !reference.init
+      );
+      if (isReassigned) return false;
+
+      seen.add(variable);
+      // Resolve the initialiser from where the variable was declared, so an
+      // unrelated binding that shadows the same name at the use site can't be
+      // mistaken for it.
+      const isBoolean = checkBooleanValidity(
+        variableDef.node.init,
+        variable.scope,
+        seen
+      );
+      seen.delete(variable);
+
+      return isBoolean;
     }
 
     default:
@@ -93,8 +121,13 @@ module.exports = {
         // We're only interested in && operators
         if (node.operator !== "&&") return;
 
-        // We're only interested in JSX elements on the right-hand side
-        if (node.right.type !== "JSXElement") return;
+        // `cond && <div />` and `cond && <>…</>` both leak the left-hand value
+        // into the tree when it's falsy, so both sides need the guard.
+        if (
+          node.right.type !== "JSXElement" &&
+          node.right.type !== "JSXFragment"
+        )
+          return;
 
         // Left-hand side part of the expression
         const { left } = node;
@@ -112,9 +145,18 @@ module.exports = {
           node,
           messageId: "booleanConversion",
           fix(fixer) {
+            const text = sourceCode.getText(left);
+
+            // A comma expression would split into separate arguments inside
+            // Boolean(), which then tests the first operand instead of the
+            // one the expression evaluates to, so it keeps its own
+            // parentheses. Nothing else binds looser than an argument.
+            const argument =
+              left.type === "SequenceExpression" ? `(${text})` : text;
+
             return fixer.replaceTextRange(
               [left.range[0], left.range[1]],
-              `Boolean(${sourceCode.getText(left)})`
+              `Boolean(${argument})`
             );
           },
         });


### PR DESCRIPTION
The rule read a variable's declarator initialiser and ignored every write after it, so `let a = true; a = 0; a && <div />` passed as safe. An initialiser now only counts when nothing writes to the variable afterwards, and it resolves from the declaration scope rather than the use site, so in `const a = t; () => { const t = true; return a && <div /> }` the inner `t` no longer vouches for `a`.

Also fixed:

- `let a;` and the bindings in `for (const x of xs)` / `for (const k in o)` have a null init. Reading `type` off it threw a `TypeError` and took the whole lint run down with it.
- `var a = a;` resolved to itself and recursed until the stack overflowed (`RangeError`). The cycle guard tracks the current resolution path rather than everything seen, so `a && a` still isn't reported.
- `cond && <>...</>` was skipped. Only `JSXElement` was checked, and a fragment renders a falsy left operand the same way.
- `(a, b) && <div />` autofixed to `Boolean(a, b)`, which tests `a` when the comma expression's value is `b`. The fix now wraps it: `Boolean((a, b))`.

Twelve cases added, ten of which fail on main. The two valid ones pin the cycle guard and the fragment path so a later fix doesn't start reporting them.

Per ESLint's semver policy this is a minor, since it reports on code that used to slip through.

## Proof

The new cases on main, the same cases with the fix, and a third run of the built `lib/` through the ESLint API.

![ten tests failing on main, all 46 passing after the fix, and the built lib output for each pattern](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-rule-soundness/safe-jsx-rule-soundness/proof-rule-soundness.png)

