### PR TITLE
fix(changelog): generate from conventional commits and backfill the history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+Generated from conventional commit messages. Breaking changes are collected
+under their own heading, from either a `!` after the type or a
+`BREAKING CHANGE:` footer.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.2.0](https://github.com/GSTJ/safe-jsx/compare/v1.1.0...v1.2.0) (2026-07-25)
+
+## [1.1.0](https://github.com/GSTJ/safe-jsx/compare/v1.0.5...v1.1.0) (2023-05-13)
+
+### Features
+
+* don't give false positives when dealing with BinaryExpressions on an && operator ([a19fe02](https://github.com/GSTJ/safe-jsx/commit/a19fe027ae81e4e78c1fd8fa644490261a85c91b))
+* make it faster, more reliable and mantainable by refactoring and removing code duplication ([3f4eefd](https://github.com/GSTJ/safe-jsx/commit/3f4eefdb56cb2e2faf7674aa096e51e6e124f678))
+* purge false-positives ([104d3ab](https://github.com/GSTJ/safe-jsx/commit/104d3ab1a98a320009944f4d5adf634e65908f74))
+* purge more tiny edge-cases and add tests to ensure they don't break ([d091787](https://github.com/GSTJ/safe-jsx/commit/d091787937ab2a4f1ee60ce3eda5d6e010654bfd))
+
+### Bug Fixes
+
+* add recursiviness to checkBooleanValidity to account for more than two variables ([d35a9a9](https://github.com/GSTJ/safe-jsx/commit/d35a9a93f5f0ab6326f173260386d73733810b59))
+* understand single negation ! boolean conversion ([c991668](https://github.com/GSTJ/safe-jsx/commit/c991668fe8a20fa7aeade4563bc9a8df11ea17de))
+* use module.exports to fix eslint plugin usage ([0d879e9](https://github.com/GSTJ/safe-jsx/commit/0d879e9827391b124b4ce4d221aa37abf6b323e8))
+
+## [1.0.5](https://github.com/GSTJ/safe-jsx/compare/v1.0.3...v1.0.5) (2023-05-12)
+
+### Features
+
+* support new boolean constructor, support !! operator as a valid boolean conversion ([06dfa64](https://github.com/GSTJ/safe-jsx/commit/06dfa649cdf8d44118ea5cde1d0f83d6faed253e))
+
+## [1.0.3](https://github.com/GSTJ/safe-jsx/compare/v1.0.1...v1.0.3) (2023-05-12)
+
+### Features
+
+* make it faster with early returns ⚡️ ([d86a810](https://github.com/GSTJ/safe-jsx/commit/d86a81054d8974970358b29113658a577a7d5725))
+
+## [1.0.1](https://github.com/GSTJ/safe-jsx/compare/b63886caa8a02664177a6c0e71181e1300f6c5be...v1.0.1) (2023-05-12)
+
+### Bug Fixes
+
+* make it usable ([b63886c](https://github.com/GSTJ/safe-jsx/commit/b63886caa8a02664177a6c0e71181e1300f6c5be))

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "prepublishOnly": "safe-publish-latest && npm run lint && npm run jest",
     "jest": "jest --coverage",
     "posttest": "npm audit --omit=dev",
-    "version": "auto-changelog && git add CHANGELOG.md",
-    "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+    "changelog": "node tools/changelog.mjs",
+    "release-notes": "node tools/release-notes.mjs",
+    "version": "npm run changelog && git add CHANGELOG.md",
+    "postversion": "node tools/release-notes.mjs > .release-notes && git tag -f -a --cleanup=verbatim \"v$npm_package_version\" -F .release-notes && rm -f .release-notes"
   },
   "author": "Gabriel Taveira",
   "license": "MIT",
@@ -41,7 +43,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^26.1.1",
     "@typescript-eslint/parser": "^8.65.0",
-    "auto-changelog": "^2.6.0",
+    "conventional-changelog-cli": "^5.0.0",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-eslint-plugin": "^7.5.0",
@@ -74,21 +76,13 @@
       "src"
     ]
   },
-  "auto-changelog": {
-    "output": "CHANGELOG.md",
-    "template": "keepachangelog",
-    "unreleased": false,
-    "commitLimit": false,
-    "backfillLimit": false,
-    "hideCredit": true,
-    "startingVersion": "6.6.2"
-  },
   "publishConfig": {
     "ignore": [
       "!lib",
       ".github/workflows",
       "/src",
       "/reports",
+      "/tools",
       "CONTRIBUTING.md"
     ]
   }

--- a/tools/changelog.mjs
+++ b/tools/changelog.mjs
@@ -1,0 +1,38 @@
+// Rebuilds CHANGELOG.md from every tag in the repo.
+//
+// conventional-changelog can only prepend, which buries the header under each
+// new release, and an incremental file drifts from git the moment a commit gets
+// amended or a tag moves. Regenerating the whole thing is instant here and the
+// output only depends on the history, so it can't drift.
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const header = `# Changelog
+
+Generated from conventional commit messages. Breaking changes are collected
+under their own heading, from either a \`!\` after the type or a
+\`BREAKING CHANGE:\` footer.
+
+`;
+
+const body = execFileSync(
+  process.platform === "win32" ? "npx.cmd" : "npx",
+  [
+    "conventional-changelog",
+    "--preset",
+    "conventionalcommits",
+    "--release-count",
+    "0",
+  ],
+  { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+);
+
+if (!body.trim()) {
+  console.error(
+    "conventional-changelog produced nothing, refusing to write an empty changelog"
+  );
+  process.exit(1);
+}
+
+writeFileSync("CHANGELOG.md", header + body.trimStart());
+console.log("CHANGELOG.md rebuilt");

--- a/tools/release-notes.mjs
+++ b/tools/release-notes.mjs
@@ -1,0 +1,20 @@
+// Prints the newest section of CHANGELOG.md.
+//
+// Both the annotated git tag and the GitHub release body are built from this, so
+// the three places a reader might look at a release all say the same thing,
+// breaking changes included.
+import { readFileSync } from "node:fs";
+
+const changelog = readFileSync("CHANGELOG.md", "utf8");
+
+// Only `## ` starts a release. `### ` headings are the type groups inside one.
+const releases = changelog
+  .split(/^(?=## )/m)
+  .filter((part) => part.startsWith("## "));
+
+if (releases.length === 0) {
+  console.error("no release sections found in CHANGELOG.md");
+  process.exit(1);
+}
+
+process.stdout.write(`${releases[0].trim()}\n`);


### PR DESCRIPTION
CHANGELOG.md has been nothing but its header since the file was added. The `auto-changelog` block carried `startingVersion: 6.6.2` and the package has never been past 1.x, so every release got filtered out and each `npm version` rewrote the same empty file.

auto-changelog also groups by "Merged" and "Commits" rather than by conventional commit type. A `!` survived only as characters in the subject line, and a `BREAKING CHANGE:` footer never appeared at all, since the template renders subjects and drops bodies.

conventional-changelog with the conventionalcommits preset groups by type and collects breaking changes under their own heading from both forms. `tools/changelog.mjs` rebuilds the file from every tag instead of prepending, so it can't drift from git, and backfills v1.0.1, v1.0.3, v1.0.5 and v1.1.0. v1.2.0 renders as a heading with no entries, since none of its commits were `feat` or `fix`.

`tools/release-notes.mjs` prints the newest section. `postversion` feeds it into an annotated tag instead of overwriting npm's annotated tag with a lightweight one, and the GitHub release body comes from CHANGELOG.md too, so the changelog, the tag and the release can't disagree. The tag needs `--cleanup=verbatim`, since git otherwise strips every line starting with `#` and the version and breaking-change headings go with them.

## Proof

The broken config, and `npm version minor` in a throwaway clone carrying a `fix:`, a `feat!:` and a `BREAKING CHANGE:` footer.

![the startingVersion 6.6.2 config against a 1.2.0 package, the generated changelog with a breaking changes heading, and the same notes on the annotated tag](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-changelog-backfill/safe-jsx-changelog-backfill/proof-changelog.png)

