### PR TITLE
ci: call the magic reusable workflow at @v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci:
-    uses: GSTJ/magic/.github/workflows/ci.yml@main
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
     with:
       node-version: "24"
       build-command: pnpm run build


### PR DESCRIPTION
Switches `.github/workflows/ci.yml` from `GSTJ/magic/.github/workflows/ci.yml@main` to `@v1`.

`@main` meant any merge in GSTJ/magic reran this repo's CI with whatever landed there minutes earlier. `@v1` is a moving major tag, so fixes still arrive on the next run without the unreviewed-merge exposure.

### Why this is safe to merge blind

`v1` and `v1.4.0` are the same commit, and `git diff v1 origin/main -- .github/workflows/ci.yml .github/actions/setup/` is empty. The workflow this repo runs today and the one it will run after this PR are byte-identical — only the ref we name changes.

The four inputs we pass all exist in the v1 `workflow_call` signature: `node-version`, `build-command`, `test-command`, `turbo-cache`. The job id (`ci`) and the default `job-name` are unchanged, so the required check still reports as `ci / 👮 Lint, Format, Typecheck`.

### No dependency changes

Everything is already current, so `package.json` is untouched:

| Package | Here | Latest |
| --- | --- | --- |
| magic-oxlint-config | ^1.2.0 | 1.2.0 |
| magic-oxfmt-config | ^1.2.0 | 1.2.0 |
| magic-tsconfig | ^1.2.0 | 1.2.0 |
| magic-codemods | ^1.1.0 | 1.1.0 |

`magic-oxlint-plugin@1.1.0` is not consumed here and this PR enables no rules, so it stays out. Because the lockfile never moved, the pnpm 11 quarantine two-step didn't apply — no new `minimumReleaseAgeExclude` entries. The existing ones in `pnpm-workspace.yaml` are still inside their window and stay as they are.

### Verification

Local, on this branch:

- `pnpm install --frozen-lockfile` — clean, lockfile unchanged
- `oxlint --report-unused-disable-directives` — 0 warnings, 0 errors across 8 files / 354 rules
- `oxfmt --check .` — 24 files, all correctly formatted
- `tsc --noEmit` — clean
- `pnpm run build` — clean
- `jest --coverage` — 46 passed, 2 suites

Claude-Session: https://claude.ai/code/session_01Fe92vvdc4R3F4BDBFoLcw1