### PR TITLE
chore(changelog): render the commit types that can change the tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,9 @@ jobs:
       node-version: "24"
       build-command: pnpm run build
       test-command: pnpm run test
+      # The changelog preset decides which commit types reach CHANGELOG.md, and
+      # getting it wrong drops commits silently. This renders a synthetic
+      # history through it and fails if a breaking change goes missing.
+      extra-command: pnpm run changelog:check
       # Nothing in this repo uses turbo.
       turbo-cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,41 @@ Generated from conventional commit messages. Breaking changes are collected
 under their own heading, from either a `!` after the type or a
 `BREAKING CHANGE:` footer.
 
+Releases up to 1.3.0 are kept as they were published, in
+tools/changelog-history.md.
+
 ## [1.3.1](https://github.com/GSTJ/safe-jsx/compare/v1.3.0...v1.3.1) (2026-07-28)
 
 ### Bug Fixes
 
 * **release:** stop running oxfmt over the generated CHANGELOG ([0abd1fe](https://github.com/GSTJ/safe-jsx/commit/0abd1fe55f6e883e09a8474dc5eb99d37e086c84))
+
+### Build System
+
+* drop the dev tsconfig from the tarball ([4c41336](https://github.com/GSTJ/safe-jsx/commit/4c413366e289183aca0cb525071aac656f7eeb18))
+* drop the incremental workaround ([b47fc38](https://github.com/GSTJ/safe-jsx/commit/b47fc38afe36b2e59d2ba16b636c127a5863e990))
+* keep dev config out of the tarball and fix the incremental build ([4c4b2a0](https://github.com/GSTJ/safe-jsx/commit/4c4b2a0c543e6b6b99f4266da717ee25dcefa6f3))
+
+### Code Refactoring
+
+* **rules:** make LegacyRuleContext a type alias ([4255fe3](https://github.com/GSTJ/safe-jsx/commit/4255fe3b951a81e66b83fa18c4d61bd9c7cb2e75))
+* type the plugin sources against the strict shared tsconfig ([0bc750f](https://github.com/GSTJ/safe-jsx/commit/0bc750f73b521dda2e4eb644a3e0523fe6a3aba2))
+
+### Chores
+
+* **changelog:** rebuild in the generator's own bullet style ([0f15905](https://github.com/GSTJ/safe-jsx/commit/0f15905c891d68ce524646877263b4a904db7c5e))
+* **config:** adopt the magic oxlint, oxfmt and tsconfig presets ([9423539](https://github.com/GSTJ/safe-jsx/commit/9423539818b9d53d20f82e6e86958997fc4378b7))
+* **config:** build the lint config with extendConfig ([df8f17f](https://github.com/GSTJ/safe-jsx/commit/df8f17f644787744fd714018a5de786b08cbc92e))
+* **deps:** move the magic stack to 1.1.0 ([55f8751](https://github.com/GSTJ/safe-jsx/commit/55f87518849789dde154fc55c2b119e144399a8e))
+* **deps:** move the magic stack to 1.2.0 ([008b298](https://github.com/GSTJ/safe-jsx/commit/008b298024171fae03e1ef2f6da38ed2abd11f6d))
+* **deps:** move to pnpm and swap eslint/prettier tooling for the magic stack ([faceee1](https://github.com/GSTJ/safe-jsx/commit/faceee1310e32e5f4bf91ec3b6122c4e3db0adee))
+* **deps:** replace the deprecated conventional-changelog-cli ([27f1e1e](https://github.com/GSTJ/safe-jsx/commit/27f1e1edb5ccaf1f6436e680ea37044eb56754fa)), references [#33](https://github.com/GSTJ/safe-jsx/issues/33)
+* **renovate:** say what actually sets the typescript ceiling ([11a0f20](https://github.com/GSTJ/safe-jsx/commit/11a0f20f90cc1b4706e3542b99d82c73120dd9c6))
+
+### Documentation
+
+* **config:** correct why this config uses extendConfig ([2fc12b3](https://github.com/GSTJ/safe-jsx/commit/2fc12b383bc9d92ac3c4169dc42b20d5c2fa5410))
+* **config:** say why the eslint-plugin meta rules are not wired up ([9cef61c](https://github.com/GSTJ/safe-jsx/commit/9cef61c8d6c185e555362a94b97872f9c68966fe))
 
 ## [1.3.0](https://github.com/GSTJ/safe-jsx/compare/v1.2.0...v1.3.0) (2026-07-27)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,25 @@ This describes the kind of change that this commit is providing.
 
 - **feat** (new feature for the user, not a new feature for build script)
 - **fix** (bug fix for the user, not a fix to a build script)
-- **docs** (changes to the documentation)
-- **style** (formatting, missing semi colons, etc; no production code change)
+- **perf** (a change that makes the plugin faster)
+- **revert** (undoing an earlier commit)
+- **build** (the build, the tarball contents, or what gets published)
 - **refactor** (refactoring production code, eg. renaming a variable)
+- **chore** (dependency bumps, tooling config; no production code change)
+- **docs** (changes to the documentation)
+- **ci** (workflows and anything else under `.github/`)
+- **style** (formatting, missing semi colons, etc; no production code change)
 - **test** (adding missing tests, refactoring tests; no production code change)
-- **chore** (updating grunt tasks etc; no production code change)
+
+The first eight land in `CHANGELOG.md` under their own heading. `ci`, `style` and
+`test` do not, because nothing they touch can reach the published tarball. Only
+`feat`, `fix`, `perf` and `revert` affect the version bump, so a release built
+entirely from `build` and `chore` commits is still a patch.
+
+That split lives in `tools/changelog-preset.mjs`, and
+`pnpm run changelog:check` renders a synthetic history through it to prove
+nothing silently disappears. Breaking changes are the exception to all of it and
+are never hidden, whatever type they hang off.
 
 #### `<scope>`
 

--- a/oxfmt.config.mts
+++ b/oxfmt.config.mts
@@ -1,1 +1,17 @@
-export { default } from "magic-oxfmt-config";
+import base from "magic-oxfmt-config";
+
+// tools/changelog-history.md holds the releases up to 1.3.0 exactly as they were
+// published, and tools/changelog.mjs pastes it onto the end of every rebuild.
+// Formatting it would rewrite `*` bullets to `-` — the same churn the shared
+// config already ignores `**/CHANGELOG.md` to avoid — and the frozen text would
+// stop matching the notes that actually shipped.
+//
+// There is a `withoutIgnorePatterns` helper for the other direction but none for
+// adding, and the package's own docs say spreading by hand is supported.
+export default {
+  ...base,
+  ignorePatterns: [
+    ...(base.ignorePatterns ?? []),
+    "tools/changelog-history.md",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "prepublishOnly": "safe-publish-latest && npm run lint && npm run test",
     "changelog": "node tools/changelog.mjs",
+    "changelog:check": "node tools/changelog-check.mjs",
     "release-notes": "node tools/release-notes.mjs",
     "version": "npm run changelog && git add CHANGELOG.md",
     "postversion": "node tools/release-notes.mjs > .release-notes && git tag -f -a --cleanup=verbatim \"v$npm_package_version\" -F .release-notes && rm -f .release-notes"

--- a/tools/changelog-check.mjs
+++ b/tools/changelog-check.mjs
@@ -125,6 +125,12 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
+// `--print` is for looking at the control by hand, which is the only way to
+// judge the section names and ordering. The assertions above cannot.
+if (process.argv.includes("--print")) {
+  console.log(output);
+}
+
 console.log(
   `changelog preset check passed (${COMMITS.length} synthetic commits, 3 breaking)`,
 );

--- a/tools/changelog-check.mjs
+++ b/tools/changelog-check.mjs
@@ -1,0 +1,130 @@
+// Positive control for tools/changelog-preset.mjs.
+//
+// The preset decides which commit types reach the changelog, so the risk it
+// carries is silent omission: mark a type `hidden` and its commits vanish with
+// no error anywhere. A breaking change vanishing that way is the one failure
+// this repo cannot ship, and CONTRIBUTING.md promises it won't.
+//
+// So this builds a throwaway repo with one commit of every type, renders it
+// through the real preset, and asserts on what comes back. The `ci!:` commit is
+// the case worth having: `ci` is hidden, and its breaking note still has to
+// surface.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const here = import.meta.dirname;
+const presetPath = join(here, "changelog-preset.mjs");
+const cliPath = join(
+  here,
+  "..",
+  "node_modules",
+  ".bin",
+  "conventional-changelog",
+);
+
+const COMMITS = [
+  "feat: add a thing",
+  "fix: correct a thing",
+  "build: shrink the tarball",
+  "refactor: rewrite the internals",
+  "chore(deps): bump something",
+  "docs: update the readme",
+  "ci: tweak the workflow",
+  "style: reformat",
+  "test: add cases",
+  "perf!: drop the slow path\n\nBREAKING CHANGE: the slow path is gone",
+  "chore: retire the legacy loader\n\nBREAKING CHANGE: the legacy loader is gone",
+  "ci!: require node 24\n\nBREAKING CHANGE: node 22 is no longer supported",
+];
+
+const repo = mkdtempSync(join(tmpdir(), "safe-jsx-changelog-"));
+/** @param {string[]} args */
+const git = (...args) =>
+  execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: "pipe" });
+
+let output;
+
+try {
+  git("init", "--quiet", "--initial-branch", "main");
+  git("config", "user.email", "check@example.com");
+  git("config", "user.name", "changelog check");
+  writeFileSync(
+    join(repo, "package.json"),
+    JSON.stringify({ name: "changelog-check", version: "1.0.0" }),
+  );
+  git("add", ".");
+
+  for (const message of COMMITS) {
+    git(
+      "commit",
+      "--quiet",
+      "--allow-empty",
+      "--cleanup=verbatim",
+      "-m",
+      message,
+    );
+  }
+
+  git("tag", "-a", "v1.0.0", "-m", "v1.0.0");
+
+  output = execFileSync(
+    cliPath,
+    ["--config", presetPath, "--release-count", "0", "--stdout"],
+    { cwd: repo, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+} finally {
+  rmSync(repo, { recursive: true, force: true });
+}
+
+/** @type {string[]} */
+const failures = [];
+/**
+ * @param {string} label
+ * @param {boolean} condition
+ */
+const expect = (label, condition) => {
+  if (!condition) failures.push(label);
+};
+
+// Breaking changes render whatever type they hang off, hidden ones included.
+// The preset prefixes the heading with a warning sign, so match on the words.
+expect("BREAKING CHANGES heading", /^### .*BREAKING CHANGES$/m.test(output));
+expect(
+  "breaking note on a bump type (perf!)",
+  output.includes("the slow path is gone"),
+);
+expect(
+  "breaking note on a changelog type (chore!)",
+  output.includes("the legacy loader is gone"),
+);
+expect(
+  "breaking note on a HIDDEN type (ci!)",
+  output.includes("node 22 is no longer supported"),
+);
+
+// The types that can change the published artifact.
+expect("Features section", output.includes("### Features"));
+expect("Bug Fixes section", output.includes("### Bug Fixes"));
+expect("Build System section", output.includes("shrink the tarball"));
+expect("Code Refactoring section", output.includes("rewrite the internals"));
+expect("Chores section", output.includes("bump something"));
+expect("Documentation section", output.includes("update the readme"));
+
+// The types that cannot. A non-breaking commit of each stays out.
+expect("ci stays hidden", !output.includes("tweak the workflow"));
+expect("style stays hidden", !output.includes("reformat"));
+expect("test stays hidden", !output.includes("add cases"));
+
+if (failures.length > 0) {
+  console.error("changelog preset check FAILED:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  console.error("\n--- rendered output ---\n");
+  console.error(output);
+  process.exit(1);
+}
+
+console.log(
+  `changelog preset check passed (${COMMITS.length} synthetic commits, 3 breaking)`,
+);

--- a/tools/changelog-history.md
+++ b/tools/changelog-history.md
@@ -1,0 +1,41 @@
+## [1.3.0](https://github.com/GSTJ/safe-jsx/compare/v1.2.0...v1.3.0) (2026-07-27)
+
+### Bug Fixes
+
+* **changelog:** generate from conventional commits and backfill the history ([#37](https://github.com/GSTJ/safe-jsx/issues/37)) ([7d15caf](https://github.com/GSTJ/safe-jsx/commit/7d15cafc495d0867820a3c0a6548b0016c868b06))
+* **jsx-explicit-boolean:** five soundness bugs in the boolean check ([#36](https://github.com/GSTJ/safe-jsx/issues/36)) ([7f0ba25](https://github.com/GSTJ/safe-jsx/commit/7f0ba25a535d2c74f2ef8331cdd1511df2c0647c))
+
+## [1.2.0](https://github.com/GSTJ/safe-jsx/compare/v1.1.0...v1.2.0) (2026-07-25)
+
+## [1.1.0](https://github.com/GSTJ/safe-jsx/compare/v1.0.5...v1.1.0) (2023-05-13)
+
+### Features
+
+* don't give false positives when dealing with BinaryExpressions on an && operator ([a19fe02](https://github.com/GSTJ/safe-jsx/commit/a19fe027ae81e4e78c1fd8fa644490261a85c91b))
+* make it faster, more reliable and mantainable by refactoring and removing code duplication ([3f4eefd](https://github.com/GSTJ/safe-jsx/commit/3f4eefdb56cb2e2faf7674aa096e51e6e124f678))
+* purge false-positives ([104d3ab](https://github.com/GSTJ/safe-jsx/commit/104d3ab1a98a320009944f4d5adf634e65908f74))
+* purge more tiny edge-cases and add tests to ensure they don't break ([d091787](https://github.com/GSTJ/safe-jsx/commit/d091787937ab2a4f1ee60ce3eda5d6e010654bfd))
+
+### Bug Fixes
+
+* add recursiviness to checkBooleanValidity to account for more than two variables ([d35a9a9](https://github.com/GSTJ/safe-jsx/commit/d35a9a93f5f0ab6326f173260386d73733810b59))
+* understand single negation ! boolean conversion ([c991668](https://github.com/GSTJ/safe-jsx/commit/c991668fe8a20fa7aeade4563bc9a8df11ea17de))
+* use module.exports to fix eslint plugin usage ([0d879e9](https://github.com/GSTJ/safe-jsx/commit/0d879e9827391b124b4ce4d221aa37abf6b323e8))
+
+## [1.0.5](https://github.com/GSTJ/safe-jsx/compare/v1.0.3...v1.0.5) (2023-05-12)
+
+### Features
+
+* support new boolean constructor, support !! operator as a valid boolean conversion ([06dfa64](https://github.com/GSTJ/safe-jsx/commit/06dfa649cdf8d44118ea5cde1d0f83d6faed253e))
+
+## [1.0.3](https://github.com/GSTJ/safe-jsx/compare/v1.0.1...v1.0.3) (2023-05-12)
+
+### Features
+
+* make it faster with early returns ⚡️ ([d86a810](https://github.com/GSTJ/safe-jsx/commit/d86a81054d8974970358b29113658a577a7d5725))
+
+## [1.0.1](https://github.com/GSTJ/safe-jsx/compare/b63886caa8a02664177a6c0e71181e1300f6c5be...v1.0.1) (2023-05-12)
+
+### Bug Fixes
+
+* make it usable ([b63886c](https://github.com/GSTJ/safe-jsx/commit/b63886caa8a02664177a6c0e71181e1300f6c5be))

--- a/tools/changelog-preset.mjs
+++ b/tools/changelog-preset.mjs
@@ -1,0 +1,49 @@
+// conventionalcommits preset, retuned so the changelog lists what actually
+// ships.
+//
+// The stock preset renders feat, fix, perf and reverts, and hides everything
+// else. That is wrong for this package. 1.3.1 shipped a rebuilt `lib/` and a
+// smaller tarball off `build:` and `refactor:` commits, and the stock preset
+// reduced the whole release to one `fix(release):` line about the changelog
+// script — the one change in it a consumer could not observe.
+//
+// So the split here is by whether a type can change the published artifact:
+//
+//   renders   feat fix perf revert   the stock set
+//             build                  tsconfig, publishConfig, the emitted lib/
+//             refactor               rewrites the emitted lib/
+//             chore                  dependency and config moves land in lib/
+//             docs                   README.md is inside the tarball
+//
+//   hidden    ci                     .github/workflows is publishConfig.ignore'd
+//             style                  formatting source cannot move tsc's output
+//             test                   src/**/*.test.* is excluded from the build
+//
+// `effect: "changelog"` is the important part: it renders the type without
+// letting it drive the version bump, so a pile of `build:` commits still adds
+// up to a patch. Only the `bump` types can raise that, exactly as before.
+//
+// Breaking changes are not configurable here and do not need to be. The preset's
+// writer sets `discard = false` the moment a commit carries a note, so a
+// `BREAKING CHANGE:` footer or a `!` renders its own section whatever type it
+// hangs off, including the hidden ones. tools/changelog-check.mjs is the
+// positive control for that.
+import createPreset from "conventional-changelog-conventionalcommits";
+
+/** @type {import("conventional-changelog-conventionalcommits").CommitType[]} */
+export const TYPES = [
+  { type: "feat", section: "Features", effect: "bump" },
+  { type: "feature", section: "Features", effect: "bump" },
+  { type: "fix", section: "Bug Fixes", effect: "bump" },
+  { type: "perf", section: "Performance Improvements", effect: "bump" },
+  { type: "revert", section: "Reverts", effect: "bump" },
+  { type: "build", section: "Build System", effect: "changelog" },
+  { type: "refactor", section: "Code Refactoring", effect: "changelog" },
+  { type: "chore", section: "Chores", effect: "changelog" },
+  { type: "docs", section: "Documentation", effect: "changelog" },
+  { type: "ci", section: "Continuous Integration", effect: "hidden" },
+  { type: "style", section: "Styles", effect: "hidden" },
+  { type: "test", section: "Tests", effect: "hidden" },
+];
+
+export default createPreset({ types: TYPES });

--- a/tools/changelog.mjs
+++ b/tools/changelog.mjs
@@ -1,11 +1,26 @@
-// Rebuilds CHANGELOG.md from every tag in the repo.
+// Rebuilds CHANGELOG.md from the tags in the repo.
 //
 // conventional-changelog can only prepend, which buries the header under each
 // new release, and an incremental file drifts from git the moment a commit gets
-// amended or a tag moves. Regenerating the whole thing is instant here and the
-// output only depends on the history, so it can't drift.
+// amended or a tag moves. Regenerating is instant here and the output only
+// depends on the history, so it can't drift.
+//
+// Releases up to and including FROZEN_AT are the exception: they come from
+// tools/changelog-history.md verbatim. tools/changelog-preset.mjs renders
+// build, refactor, chore and docs, which the old config hid, and regenerating
+// the old releases under it would rewrite sections that shipped as far back as
+// 2023 — it also moves 1.0.1's compare link, since the first commit the range
+// starts from changes once chore is visible. Published notes stay as published.
+// Everything above the freeze is still generated from git on every run.
 import { execFileSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const FROZEN_AT = "1.3.0";
+
+const here = import.meta.dirname;
+const historyPath = join(here, "changelog-history.md");
+const presetPath = join(here, "changelog-preset.mjs");
 
 const header = `# Changelog
 
@@ -13,18 +28,21 @@ Generated from conventional commit messages. Breaking changes are collected
 under their own heading, from either a \`!\` after the type or a
 \`BREAKING CHANGE:\` footer.
 
+Releases up to ${FROZEN_AT} are kept as they were published, in
+tools/changelog-history.md.
+
 `;
 
 const body = execFileSync(
   process.platform === "win32" ? "npx.cmd" : "npx",
   [
     "conventional-changelog",
-    "--preset",
-    "conventionalcommits",
+    "--config",
+    presetPath,
     "--release-count",
     "0",
     // Without this the CLI writes CHANGELOG.md itself and leaves stdout empty,
-    // which would skip the header below and trip the guard on the next line.
+    // which would skip the header and trip the guard below.
     "--stdout",
   ],
   { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
@@ -37,5 +55,19 @@ if (!body.trim()) {
   process.exit(1);
 }
 
-writeFileSync("CHANGELOG.md", header + body.trimStart());
+// Anchored on `## [` so a version string inside a commit subject can't match.
+const freezeMarker = `## [${FROZEN_AT}]`;
+const freezeIndex = body.indexOf(freezeMarker);
+
+if (freezeIndex === -1) {
+  console.error(
+    `no "${freezeMarker}" section in the generated output. Either the ${FROZEN_AT} tag went missing or FROZEN_AT is stale; refusing to write a changelog that would drop the frozen history.`,
+  );
+  process.exit(1);
+}
+
+const generated = body.slice(0, freezeIndex).trim();
+const history = readFileSync(historyPath, "utf8").trim();
+
+writeFileSync("CHANGELOG.md", `${header + generated}\n\n${history}\n`);
 console.log("CHANGELOG.md rebuilt");


### PR DESCRIPTION
The changelog should list build and refactor (open question from #41).

1.3.1 shipped a rebuilt `lib/` and a tarball three files smaller. Its changelog entry lists one `fix(release):` line about the changelog script. The stock conventionalcommits preset renders feat, fix, perf and reverts and drops the rest.

## Sections

The split is by whether a type can reach the published artifact.

| Renders | Why |
| --- | --- |
| feat, fix, perf, revert | the stock set |
| build | tsconfig, publishConfig, the emitted `lib/` |
| refactor | rewrites the emitted `lib/` |
| chore | dependency and config moves land in `lib/` |
| docs | README.md is inside the tarball |

`ci`, `style` and `test` stay hidden: `.github/workflows` is `publishConfig.ignore`'d, formatting source can't move tsc's output, and the tests are excluded from the build.

`effect: "changelog"` renders a type without letting it drive the version bump, so a release of nothing but `build:` commits is still a patch. Only feat/fix/perf/revert can raise that.

Section names follow the canonical conventionalcommits ones, which is what react-native-code-push-plugin already uses. The portfolio uses its own set (`Refactors`, `Build`, `Chores`). I matched the npm-package one.

## Frozen history

The generator rebuilds the whole file, so switching types would have rewritten notes going back to 2023. It also moves 1.0.1's compare link, because the commit the range starts from changes once `chore` is visible.

So releases up to 1.3.0 now come from `tools/changelog-history.md` verbatim, and everything above the freeze is still generated from git. That corrects the 1.3.1 entry in place. Nothing gets republished.

![changelog sections](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-changelog-sections/safe-jsx-changelog-sections/changelog-sections.png)

## Breaking changes

Untouched, and now pinned down by a check. The preset's writer sets `discard = false` the moment a commit carries a note, so a `!` or a `BREAKING CHANGE:` footer renders whatever type it hangs off, hidden ones included.

`tools/changelog-check.mjs` builds a throwaway repo with one commit of every type and renders it through the real preset. Three of the twelve are breaking. One of them is a `ci!:` commit, where `ci` is hidden and the note still has to surface.

![breaking control](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-changelog-sections/safe-jsx-changelog-sections/breaking-control.png)

It asserts the reverse too, so a plain `ci:`/`style:`/`test:` commit staying out is also checked. Flipping `build` to `hidden` makes it report `Build System section` and exit 1. Runs in CI through the reusable workflow's `extra-command`.

![controls](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-changelog-sections/safe-jsx-changelog-sections/preset-controls.png)

## Out of scope

No release. The tarball is unchanged and 1.3.1 is already out.

The v1.3.1 annotated tag still carries the old one-line notes. Moving a published tag is worse than the inconsistency, so I left it and updated the GitHub release body instead.

`npm publish` also warns that `publishConfig.ignore` stops working in the next npm major. There's nothing to move: it's npmignore's own documented config location, read straight out of `package.json` by `node_modules/npmignore/bin/npmignore`. The fix is dropping npmignore for npm's native `files`, which changes the tarball and wants its own release.
