### PR TITLE
fix(deps): make the eslint peer optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9 || ^10"
   },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
+  },
   "jest": {
     "coverageDirectory": "coverage",
     "coverageReporters": [


### PR DESCRIPTION
Declaring the `eslint` peer as required makes pnpm's autoInstallPeers, and npm since 7, install eslint next to this plugin, and the published `lib/` never touches it.

Both shipped files import eslint as `import type`, which TypeScript erases. The only runtime requires in the tarball are `../package.json` and `./rules/jsx-explicit-boolean`. The tests do use the real module through `RuleTester` and the `ESLint` API, and they're excluded from the build and from the tarball.

A project that depends on this plugin and nothing else drops from 71 packages to 1:

```
eslint-plugin-safe-jsx@1.3.1, as published     71 packages
  eslint          : eslint@10.8.0
  brace-expansion : brace-expansion@5.0.8

...with the peer marked optional                1 package
  eslint          : NOT INSTALLED
  brace-expansion : NOT INSTALLED
```

What brought this up is GHSA-mh99-v99m-4gvg, and that shows up one level out. `magic-oxlint-config` depends on this plugin and on `eslint-plugin-react-native@5.0.0`, whose peer range caps at eslint 9. Intersecting the two ranges pins resolution to eslint 9, which still depends on `minimatch@^3.1.2` and so on `brace-expansion@1.1.16`. oxlint loads the rule through its own jsPlugin host, so eslint never executes there, but it's installed in every consumer of the preset:

```
magic-oxlint-config@1.2.0, as published        91 packages, 1 high advisory
  eslint          : eslint@9.39.5
  brace-expansion : brace-expansion@1.1.16

...with only this plugin's peer optional       91 packages, 1 high advisory
...with both plugins' peers optional            5 packages, clean
```

This patch doesn't clear the advisory on its own. `eslint-plugin-react-native` declares the same peer as required, so it keeps pulling eslint 9 regardless of what this package does. That side is being handled in the magic repo.

Nobody consuming this plugin with eslint loses anything. You can't run eslint without installing it, so it's already in the tree, and pnpm and npm still version-check an optional peer when it's present.

The emitted `lib/` is byte-identical to 1.3.1. The whole diff to the published artifact is five lines of manifest.

Peer resolution across the three trees
![peer trees](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-optional-eslint-peer/safe-jsx-optional-eslint-peer/peer-trees.png)

Suite green with eslint present as a dev dep, and the rest of the tarball unchanged
![checks and tarball](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-optional-eslint-peer/safe-jsx-optional-eslint-peer/checks-and-tarball.png)
