### PR TITLE
build: keep CHANGELOG.md in the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "git+https://github.com/GSTJ/safe-jsx.git"
   },
   "files": [
+    "CHANGELOG.md",
     "lib"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
Puts `CHANGELOG.md` back in the published tarball.

#44 swapped `publishConfig.ignore` for a `files` array, which killed the npm warning. It also narrowed `files` to `lib`, and that dropped seven files 1.3.2 had been shipping. 1.3.3 went out that way, so the package on npm no longer carries a changelog.

Six of the seven are repo plumbing: `.github/FUNDING.yml`, the two issue templates, `renovate.json`, `CODE_OF_CONDUCT.md`, `SECURITY.md`. Nothing that installs the plugin reads them and I'd leave them out. `CHANGELOG.md` is regenerated on every release and it's the only one of the seven anyone would open from `node_modules`.

![what ships in the tarball](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-publishconfig-ignore/safe-jsx-publishconfig-ignore/changelog-restore.png)

Checked with `npm pack`, against the 1.3.2 and 1.3.3 tarballs from registry.npmjs.org:

- 1.3.3 ships 5 files, this branch ships 6, and the delta is exactly `+CHANGELOG.md`
- the restored file is byte-identical to the copy 1.3.2 shipped, sha256 `0e1a8377a1b61ced445a78654f37b1e0797694abf18e66b04d7384fb067076e0`
- both `lib/` outputs are untouched

`build:` renders in the changelog without driving a bump, so this doesn't need a release of its own. lint, format, typecheck and the 46 tests pass locally.
