### PR TITLE
chore: drop the npmignore leftovers from #44

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ npm-shrinkwrap.json
 package-lock.json
 yarn-error.log
 yarn.lock
-
-.npmignore

--- a/tools/changelog-preset.mjs
+++ b/tools/changelog-preset.mjs
@@ -10,12 +10,12 @@
 // So the split here is by whether a type can change the published artifact:
 //
 //   renders   feat fix perf revert   the stock set
-//             build                  tsconfig, publishConfig, the emitted lib/
+//             build                  tsconfig, the files field, the emitted lib/
 //             refactor               rewrites the emitted lib/
 //             chore                  dependency and config moves land in lib/
 //             docs                   README.md is inside the tarball
 //
-//   hidden    ci                     .github/workflows is publishConfig.ignore'd
+//   hidden    ci                     .github/ is outside the files field
 //             style                  formatting source cannot move tsc's output
 //             test                   src/**/*.test.* is excluded from the build
 //


### PR DESCRIPTION
Drops the dead `.npmignore` line from `.gitignore` and corrects two stale comments in `tools/changelog-preset.mjs`.

#44 removed `publishConfig.ignore` and the `npmignore` dev dependency. Nothing writes an `.npmignore` here anymore, and that ignore line has nothing left to catch.

The preset still explains the hidden `ci:` type by pointing at `publishConfig.ignore`, and its `build:` line still lists `publishConfig` as an example of what a build commit touches. Both name a key that's been gone since #44. `.github/` stays out of the tarball because `files` doesn't list it. The comment says that now.

![tarball unchanged](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-npmignore-leftovers/safe-jsx-npmignore-leftovers/tarball-unchanged.png)

Neither `.gitignore` nor `tools/` is inside the `files` array. `npm pack` on main and on this branch, same `lib/` input, gives 6 files each way with all six sha256 equal. oxlint straight from `node_modules/.bin`, plus oxfmt, tsc and the 46 tests, all pass locally.

`chore:` renders in the changelog without driving a bump.
