### PR TITLE
build: rewrite the security policy and ship it in the tarball

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,12 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.1.x   | :white_check_mark: |
-
 ## Reporting a Vulnerability
 
-Create an issue with the tag "vulnerability" and we will review it with priority.
+Report it privately through GitHub's advisory form:
+https://github.com/GSTJ/safe-jsx/security/advisories/new
+
+Don't open a public issue for a security problem.
+
+## Supported Versions
+
+Fixes ship in a new release off the latest published version. Stay on it; there are no backport branches.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "CHANGELOG.md",
+    "SECURITY.md",
     "lib"
   ],
   "main": "lib/index.js",


### PR DESCRIPTION
Replaces the security policy and puts it in the tarball.

The old `SECURITY.md` was written on 2023-05-13 and never touched again. Its supported-versions table listed `1.1.x` as the only supported line. The package is on 1.3.4.

Its only reporting route was "create an issue with the tag vulnerability". That's a public tracker.

I turned private vulnerability reporting on for this repo, so the policy points at the advisory form:
https://github.com/GSTJ/safe-jsx/security/advisories/new

I left the version table out rather than correcting it, because there are no backport branches to describe. There's no response-time promise in it either.

![tarball delta](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-security-policy/safe-jsx-security-policy/security-tarball-delta.png)

Adding `SECURITY.md` to `files` is what puts it in front of someone auditing a vendored copy. Checked against `eslint-plugin-safe-jsx@1.3.4` pulled from registry.npmjs.org and extracted: the delta is exactly one new path. Every file carried over is byte-identical, and `package.json` changes by the single `"SECURITY.md",` line. oxlint straight from `node_modules/.bin`, plus oxfmt, tsc and the 46 tests, all pass locally.

This one does change the published artifact, so it needs a patch release. The same file goes into the other four publishing repos as a repo file only, without touching their `files` arrays.
