### PR TITLE
fix(jsx-explicit-boolean): stop trusting a shadowed Boolean

### DIFF
--- a/src/rules/jsx-explicit-boolean.test.tsx
+++ b/src/rules/jsx-explicit-boolean.test.tsx
@@ -60,6 +60,17 @@ ruleTester.run("jsx-explicit-boolean", require("./jsx-explicit-boolean"), {
     // seeing `a` on the left must not poison `a` on the right.
     { code: "const a = true; (a && a) && <div />;" },
     { code: "const a = true; a && <>{a}</>;" },
+
+    // A shadow that does not reach the call site leaves the global alone.
+    {
+      code: "const C = () => { const Boolean = (x) => x; return Boolean; }; const a = 0; Boolean(a) && <div />;",
+    },
+    // `Boolean` declared as a global rather than in the file is still the
+    // global: it resolves to a variable with no defs.
+    {
+      code: "const a = 0; Boolean(a) && <div />;",
+      languageOptions: { globals: { Boolean: "readonly" } },
+    },
   ],
   invalid: [
     // Conditional expressions
@@ -210,6 +221,64 @@ ruleTester.run("jsx-explicit-boolean", require("./jsx-explicit-boolean"), {
       errors: [{ messageId: "booleanConversion" }],
       output:
         "const a = t; const Component = () => { const t = true; return Boolean(a) && <div />; };",
+    },
+
+    // A shadowed `Boolean`. The rule recommends `Boolean(…)` as the guard, so
+    // trusting the name wherever it appears meant a binding that shadows it
+    // turned the guard into whatever that binding does — here, nothing, and
+    // `0` reaches the tree with the rule quiet. `output` is null on all of
+    // these because the fix would write the shadow's name: it would not fix
+    // anything, and `--fix` would nest the call once per pass.
+    {
+      code: "const Boolean = (x) => x; const a = 0; Boolean(a) && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+    {
+      code: "function Boolean(x) { return x; } const a = 0; Boolean(a) && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+    {
+      code: "import { Boolean } from './shim'; const a = 0; Boolean(a) && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+    {
+      code: "const C = (Boolean) => <View>{Boolean(0) && <Text />}</View>;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+    {
+      code: "class Boolean { constructor(x) { return x; } } const a = 0; new Boolean(a) && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+    // The shadow also stops vouching for a variable that was initialised
+    // through it.
+    {
+      code: "const Boolean = (x) => x; const a = Boolean(0); a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: null,
+    },
+
+    // A destructuring pattern. The declarator's init belongs to the pattern,
+    // not to any one name it binds, and reading it as the binding's value let
+    // a boolean-looking right-hand side vouch for a name it never produced.
+    {
+      code: "const flag = true; const { a } = flag; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "const flag = true; const { a } = flag; Boolean(a) && <div />;",
+    },
+    {
+      code: "const flag = true; const [a] = flag; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "const flag = true; const [a] = flag; Boolean(a) && <div />;",
+    },
+    {
+      code: "const { a } = !b; a && <div />;",
+      errors: [{ messageId: "booleanConversion" }],
+      output: "const { a } = !b; Boolean(a) && <div />;",
     },
   ],
 });

--- a/src/rules/jsx-explicit-boolean.ts
+++ b/src/rules/jsx-explicit-boolean.ts
@@ -28,6 +28,42 @@ const isVariableDefinition = (
   definition: Scope.Definition,
 ): definition is VariableDefinition => definition.type === "Variable";
 
+// `Boolean(…)` is trusted by name, which is only sound while the name is the
+// global. `const Boolean = (x) => x` turns the very escape hatch this rule
+// recommends into a no-op, and the rule would bless `Boolean(0) && <Text />`.
+//
+// A global supplied through `languageOptions.globals` resolves to a variable
+// with no defs, so the presence of a def is what separates a binding written in
+// this file from the built-in.
+const isShadowed = (scope: Scope.Scope | null, name: string): boolean => {
+  const variable = findVariable(scope, name);
+  return variable !== null && variable.defs.length > 0;
+};
+
+/**
+ * The declaration whose initialiser can stand in for `variable`, or null when
+ * nothing about the binding makes that initialiser evidence of anything.
+ */
+const evidenceFor = (variable: Scope.Variable): VariableDefinition | null => {
+  const definition = variable.defs.find(isVariableDefinition);
+  if (!definition) return null;
+
+  // Only a plain `const a = …` binds the initialiser to the name. In
+  // `const { a } = flag` the declarator's init is `flag`, which says nothing
+  // about `a`, and reading it as evidence let a boolean-looking right-hand side
+  // vouch for a binding it never produced.
+  if (definition.node.id.type !== "Identifier") return null;
+
+  // Any write after the declaration makes the initialiser useless as evidence:
+  // `let a = true; a = 0;` isn't a boolean by the time it's used.
+  const isReassigned = variable.references.some(
+    (reference) => reference.isWrite() && !reference.init,
+  );
+  if (isReassigned) return null;
+
+  return definition;
+};
+
 // `seen` holds the variables on the current resolution path, so a declaration
 // that refers back to itself stops instead of recursing forever.
 const checkBooleanValidity = (
@@ -52,11 +88,13 @@ const checkBooleanValidity = (
     case "BinaryExpression":
       return binaryExpressionOperators.has(node.operator);
 
-    // Example: Boolean(a) or new Boolean(a)
+    // Example: Boolean(a) or new Boolean(a), and only the global one.
     case "CallExpression":
     case "NewExpression":
       return (
-        node.callee.type === "Identifier" && node.callee.name === "Boolean"
+        node.callee.type === "Identifier" &&
+        node.callee.name === "Boolean" &&
+        !isShadowed(scope, "Boolean")
       );
 
     // Example: a && b && c && <div />, where all operands are boolean
@@ -81,27 +119,18 @@ const checkBooleanValidity = (
 
     case "Identifier": {
       const variable = findVariable(scope, node.name);
-      if (!variable) return false;
-
       // `var a = a;` resolves to itself, so bail before following it again.
-      if (seen.has(variable)) return false;
+      if (!variable || seen.has(variable)) return false;
 
-      const variableDef = variable.defs.find(isVariableDefinition);
-      if (!variableDef) return false;
-
-      // Any write after the declaration makes the initialiser useless as
-      // evidence: `let a = true; a = 0;` isn't a boolean by the time it's used.
-      const isReassigned = variable.references.some(
-        (reference) => reference.isWrite() && !reference.init,
-      );
-      if (isReassigned) return false;
+      const definition = evidenceFor(variable);
+      if (!definition) return false;
 
       seen.add(variable);
       // Resolve the initialiser from where the variable was declared, so an
       // unrelated binding that shadows the same name at the use site can't be
       // mistaken for it.
       const isBoolean = checkBooleanValidity(
-        variableDef.node.init,
+        definition.node.init,
         variable.scope,
         seen,
       );
@@ -179,6 +208,12 @@ const rule: Rule.RuleModule = {
           node,
           messageId: "booleanConversion",
           fix(fixer) {
+            // The fix writes `Boolean(…)`, so it is only a fix where that name
+            // is the global. Under a shadow the same text calls the shadow, the
+            // report survives, and `--fix` nests the call once per pass until
+            // it gives up. The report stands on its own instead.
+            if (isShadowed(scope, "Boolean")) return null;
+
             const text = sourceCode.getText(left);
 
             // A comma expression would split into separate arguments inside


### PR DESCRIPTION
The rule trusted `Boolean(x)` on the callee's name, without checking the name was the global. So a binding that shadows `Boolean` turns the guard the rule recommends into whatever that binding does, and the rule says nothing.

```jsx
import { Boolean } from "./boolean-shim";

const count = 0;

export const Badge = () => <View>{Boolean(count) && <Text>{count}</Text>}</View>;
```

v1.3.5 reports 0 problems on that. React Native renders the bare `0` and throws `Text strings must be rendered within a <Text> component`. Both runs below go through the real ESLint API against the built `lib/`.

![shadowed Boolean, before and after](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/safe-jsx-shadowed-boolean-proof/safe-jsx/security/shadowed-boolean.png)

A const, a function declaration, an import, a parameter and a class all reach it, and `new Boolean(x)` the same way.

## Fix

`Boolean` is trusted where it resolves to the global. A binding declared in the file carries defs; one supplied through `languageOptions.globals` carries none, so the defs are what separate them. Dropping that distinction and rejecting any resolved `Boolean` breaks 35 of the 57 tests.

Under a shadow the report comes with no fix. `Boolean(x)` would call the shadow, the report would survive it, and `eslint --fix` would nest the call once per pass until it gave up.

## Second hole

A declarator's initialiser was read as the value of every name it binds. In `const { a } = flag` the init is `flag`, so a boolean-looking right-hand side vouched for `a`, which the pattern never produced. Only a plain `const a = x` counts as evidence now.

## Tests

Nine invalid cases across both holes, and all nine fail against the old rule (the screenshot has the list). Two valid cases cover the other direction: a shadow that never reaches the call site leaves the global alone, and a `Boolean` declared through `globals` is still the global.

`evidenceFor` exists because pulling the identifier branch out was the cheapest way back under oxlint's complexity limit, which the added checks pushed to 22.

## Semver

This reports more errors than 1.3.5 on code that shadows `Boolean` or destructures off a boolean-looking initialiser. `fix` matches what #36 shipped under for the same kind of soundness bug, so it lands as a patch.
