### PR TITLE
chore(deps): patch brace-expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<1.1.17: 1.1.18
+  brace-expansion@>=2.0.0 <2.1.3: 2.1.4
+
 importers:
 
   .:
@@ -997,11 +1001,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3014,12 +3018,12 @@ snapshots:
 
   baseline-browser-mapping@2.11.3: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3838,11 +3842,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,13 @@
 allowBuilds:
   unrs-resolver: true
 
+# Jest still reaches older minimatch lines through its coverage and resolver
+# stack. Keep the transitive brace-expansion versions on their patched releases
+# until Jest moves those edges forward.
+overrides:
+  "brace-expansion@<1.1.17": 1.1.18
+  "brace-expansion@>=2.0.0 <2.1.3": 2.1.4
+
 # pnpm refuses packages published more recently than `minimumReleaseAge`.
 # The magic-* stack was published for this migration, so it is younger than the
 # default window; these are the versions we deliberately accepted.


### PR DESCRIPTION
## Summary

Pins the vulnerable `brace-expansion` versions reached through Jest to patched releases.

## Details

- Overrides the affected 1.x line to 1.1.18 and the affected 2.x line to 2.1.4.
- Keeps the override in pnpm's workspace config so frozen installs and CI resolve the patched versions.
- Both vulnerable paths are development-only; the published plugin has no runtime dependencies.

## Testing steps

1. Install dependencies and run the audit.

```sh
pnpm install --frozen-lockfile
pnpm audit --audit-level=low
```

The audit should report no known vulnerabilities.

2. Run the repository checks.

```sh
pnpm run lint
pnpm run format
pnpm run typecheck
pnpm run test
pnpm run build
pnpm run changelog:check
```

Every command should exit successfully.
