### PR TITLE
chore(renovate): keep overrides within major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
       "description": "Two peers set this, and neither went away with the oxlint migration. @typescript-eslint/parser@8 peers >=4.8.4 <6.1.0 and is still the parser src/rules/*.test.tsx runs RuleTester under. ts-jest@29 peers >=4.3 <7 and is the harder of the two: TypeScript 7 typechecks this package and builds a byte-identical lib/, while ts-jest refuses to load it at all with 'does not expose the JavaScript compiler API required by ts-jest'. Nothing is held back either way today, since 6.0.3 is the last of the 6.x line. Raise it when ts-jest supports TypeScript 7.",
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<6.1"
+    },
+    {
+      "description": "The overrides in pnpm-workspace.yaml pin patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
+      "matchDepTypes": ["pnpm.overrides"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Keeps Renovate's pnpm override updates within each transitive consumer's compatible major.

## Details

- Disables major update PRs for `pnpm.overrides` while leaving patch and minor updates enabled.
- Prevents repeats of #55 and #56, which tried to replace the 1.x and 2.x overrides with v5.

## Testing steps

1. Validate the Renovate config.

```sh
npm exec --yes --package=renovate -- renovate-config-validator --strict renovate.json
```

The validator should report that the config is valid.

2. Run the repository checks.

```sh
pnpm install --frozen-lockfile
pnpm audit --audit-level=low
pnpm run lint
pnpm run format
pnpm run typecheck
pnpm run test
pnpm run build
pnpm run changelog:check
```

Every command should exit successfully.
