### PR TITLE
ci: pin magic v1.12.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci:
-    uses: GSTJ/magic/.github/workflows/ci.yml@aa331e83282c2794edd474646c671f036dfabee0 # v1
+    uses: GSTJ/magic/.github/workflows/ci.yml@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
     with:
       node-version: "24"
       build-command: pnpm run build


### PR DESCRIPTION
## What changed

- move the reusable CI workflow to `GSTJ/magic` v1.12.3 at its full commit SHA
- use the first `magic` release whose internal action calls are pinned, so this repository can enforce SHA-only GitHub Action references

## Proof

- confirmed the annotated v1.12.3 tag resolves to `4c640f094849d988c7380e1512f87c46a5408515`
- `actionlint`
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck`
- `pnpm exec jest --coverage --runInBand` (59/59)
- `pnpm build`
- `pnpm run changelog:check`, including its negative control
- `pnpm audit --audit-level moderate`

After this merges, I’ll enable SHA pin enforcement on the repository and rerun CI under that policy.
