### PR TITLE
chore(deps): quarantine new releases for 14 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,11 +14,76 @@ overrides:
   "brace-expansion@>=2.0.0 <2.1.3": 2.1.4
 
 # pnpm refuses packages published more recently than `minimumReleaseAge`.
-# The magic-* stack was published for this migration, so it is younger than the
-# default window; these are the versions we deliberately accepted.
+minimumReleaseAge: 20160
+
+# magic-* is our first-party tooling, so it can move immediately. Everything
+# else stays version-specific when an existing lockfile needs grandfathering.
 minimumReleaseAgeExclude:
-  - magic-codemods@1.1.0
-  - magic-oxfmt-config@1.2.0
-  - magic-oxlint-config@1.2.0
-  - magic-tsconfig@1.2.0
-  - eslint-plugin-safe-jsx@1.3.0
+  - magic-*
+  - "@babel/generator@7.29.8"
+  - "@babel/parser@7.29.8"
+  - "@babel/traverse@7.29.8"
+  - "@babel/types@7.29.8"
+  - "@eslint-community/eslint-utils@4.10.1"
+  - "@napi-rs/wasm-runtime@1.2.2"
+  - "@oxfmt/binding-android-arm-eabi@0.62.0"
+  - "@oxfmt/binding-android-arm64@0.62.0"
+  - "@oxfmt/binding-darwin-arm64@0.62.0"
+  - "@oxfmt/binding-darwin-x64@0.62.0"
+  - "@oxfmt/binding-freebsd-x64@0.62.0"
+  - "@oxfmt/binding-linux-arm-gnueabihf@0.62.0"
+  - "@oxfmt/binding-linux-arm-musleabihf@0.62.0"
+  - "@oxfmt/binding-linux-arm64-gnu@0.62.0"
+  - "@oxfmt/binding-linux-arm64-musl@0.62.0"
+  - "@oxfmt/binding-linux-ppc64-gnu@0.62.0"
+  - "@oxfmt/binding-linux-riscv64-gnu@0.62.0"
+  - "@oxfmt/binding-linux-riscv64-musl@0.62.0"
+  - "@oxfmt/binding-linux-s390x-gnu@0.62.0"
+  - "@oxfmt/binding-linux-x64-gnu@0.62.0"
+  - "@oxfmt/binding-linux-x64-musl@0.62.0"
+  - "@oxfmt/binding-openharmony-arm64@0.62.0"
+  - "@oxfmt/binding-win32-arm64-msvc@0.62.0"
+  - "@oxfmt/binding-win32-ia32-msvc@0.62.0"
+  - "@oxfmt/binding-win32-x64-msvc@0.62.0"
+  - "@oxlint/binding-android-arm-eabi@1.77.0"
+  - "@oxlint/binding-android-arm64@1.77.0"
+  - "@oxlint/binding-darwin-arm64@1.77.0"
+  - "@oxlint/binding-darwin-x64@1.77.0"
+  - "@oxlint/binding-freebsd-x64@1.77.0"
+  - "@oxlint/binding-linux-arm-gnueabihf@1.77.0"
+  - "@oxlint/binding-linux-arm-musleabihf@1.77.0"
+  - "@oxlint/binding-linux-arm64-gnu@1.77.0"
+  - "@oxlint/binding-linux-arm64-musl@1.77.0"
+  - "@oxlint/binding-linux-ppc64-gnu@1.77.0"
+  - "@oxlint/binding-linux-riscv64-gnu@1.77.0"
+  - "@oxlint/binding-linux-riscv64-musl@1.77.0"
+  - "@oxlint/binding-linux-s390x-gnu@1.77.0"
+  - "@oxlint/binding-linux-x64-gnu@1.77.0"
+  - "@oxlint/binding-linux-x64-musl@1.77.0"
+  - "@oxlint/binding-openharmony-arm64@1.77.0"
+  - "@oxlint/binding-win32-arm64-msvc@1.77.0"
+  - "@oxlint/binding-win32-ia32-msvc@1.77.0"
+  - "@oxlint/binding-win32-x64-msvc@1.77.0"
+  - "@types/node@26.1.2"
+  - "@typescript-eslint/parser@8.66.0"
+  - "@typescript-eslint/project-service@8.66.0"
+  - "@typescript-eslint/scope-manager@8.66.0"
+  - "@typescript-eslint/tsconfig-utils@8.66.0"
+  - "@typescript-eslint/types@8.66.0"
+  - "@typescript-eslint/typescript-estree@8.66.0"
+  - "@typescript-eslint/visitor-keys@8.66.0"
+  - acorn@8.18.0
+  - baseline-browser-mapping@2.11.12
+  - brace-expansion@1.1.18
+  - brace-expansion@2.1.4
+  - brace-expansion@5.0.9
+  - conventional-commits-parser@7.1.2
+  - electron-to-chromium@1.5.399
+  - eslint@10.8.0
+  - eslint-plugin-safe-jsx@1.3.6
+  - flatted@3.4.4
+  - js-yaml@3.15.1
+  - minimatch@10.2.6
+  - oxfmt@0.62.0
+  - oxlint@1.77.0
+  - ts-jest@29.4.12


### PR DESCRIPTION
## Summary

This adds a 14-day pnpm release-age floor and keeps our `magic-*` tooling available immediately.

## Details

- `minimumReleaseAge` is set to 20,160 minutes, matching the shared Renovate policy.
- `magic-*` has the only unpinned exception because we publish those packages ourselves.
- Each dependency already inside the 14-day window is grandfathered at its exact locked version. Future third-party versions need the full 14 days.

## Testing steps

1. Run the repository checks:

```sh
pnpm install --frozen-lockfile --ignore-scripts
pnpm run format
pnpm run lint
pnpm run typecheck
pnpm run test
pnpm run build
pnpm run changelog:check
pnpm audit --audit-level=low
npm audit signatures
```

2. Confirm the supply-chain policy passes, all tests pass, and both audits finish cleanly.

![Local test run](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/evidence/safe-jsx-renovate-20260804/safe-jsx/renovate-14d-tests.png)

![Supply-chain checks](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/evidence/safe-jsx-renovate-20260804/safe-jsx/renovate-14d-security.png)
