### PR TITLE
fix(package): correct the Node engine floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=14.0"
   },
   "packageManager": "pnpm@11.20.0"
 }


### PR DESCRIPTION
## Summary

The package now declares Node 14 as its minimum runtime, matching the JavaScript in the published build.

## Details

- The emitted build uses nullish coalescing, which Node 12 fails to parse.
- The Node 14 engine floor lets strict package managers reject incompatible installs before runtime.

## Testing steps

1. From the root of the checked-out repository, run:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run build
   npm pack
   ```

2. From the same directory, run:

   ```sh
   docker run --rm -v "$PWD:/package:ro" node:12-alpine sh -lc 'mkdir /app && cd /app && npm_config_engine_strict=true npm install /package/eslint-plugin-safe-jsx-1.3.7.tgz'
   ```

   The install should stop with an unsupported engine error.

3. Run:

   ```sh
   docker run --rm -v "$PWD:/package:ro" node:14-alpine sh -lc 'mkdir /app && cd /app && npm_config_engine_strict=true npm install --no-save /package/eslint-plugin-safe-jsx-1.3.7.tgz >/dev/null && node -e "console.log(require(\"eslint-plugin-safe-jsx\").meta)"'
   ```

   The command should print the plugin name and version.

4. Run the repository checks:

   ```sh
   pnpm run lint
   pnpm run format
   pnpm run typecheck
   pnpm run test
   pnpm run build
   pnpm run changelog:check
   pnpm audit --audit-level low
   ```
