### PR TITLE
release: v1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ under their own heading, from either a `!` after the type or a
 Releases up to 1.3.0 are kept as they were published, in
 tools/changelog-history.md.
 
+## [1.3.8](https://github.com/GSTJ/safe-jsx/compare/v1.3.7...v1.3.8) (2026-08-05)
+
+### Bug Fixes
+
+* **package:** correct the Node engine floor ([#72](https://github.com/GSTJ/safe-jsx/issues/72)) ([fe09789](https://github.com/GSTJ/safe-jsx/commit/fe0978959e9b3f1b92bb66dae5fe7fb28ab3fd99))
+
+### Chores
+
+* **deps:** lock file maintenance ([#70](https://github.com/GSTJ/safe-jsx/issues/70)) ([59d86c3](https://github.com/GSTJ/safe-jsx/commit/59d86c32e328879be750750ac02035d76be03bda))
+* **deps:** quarantine new releases for 14 days ([#71](https://github.com/GSTJ/safe-jsx/issues/71)) ([93dfff1](https://github.com/GSTJ/safe-jsx/commit/93dfff1a3191815877089beb7e838fac1b3a5cdb))
+* **deps:** update dependency @typescript-eslint/parser to v8.66.0 ([#67](https://github.com/GSTJ/safe-jsx/issues/67)) ([e58969d](https://github.com/GSTJ/safe-jsx/commit/e58969d2567103aa91a38363521606e494dd5605))
+* **deps:** update github actions ([#65](https://github.com/GSTJ/safe-jsx/issues/65)) ([d5fe3b1](https://github.com/GSTJ/safe-jsx/commit/d5fe3b1504fad966ffdf2d8b4cb7fde8c11f0068))
+* **deps:** update magic tooling ([#66](https://github.com/GSTJ/safe-jsx/issues/66)) ([35be0bd](https://github.com/GSTJ/safe-jsx/commit/35be0bd931c3e437aad1110fc7836c8cb42d63a7))
+* **deps:** update oxc toolchain ([#68](https://github.com/GSTJ/safe-jsx/issues/68)) ([c61ec9e](https://github.com/GSTJ/safe-jsx/commit/c61ec9e0e6f8b04c0055057c4378e5c3ec284449))
+* **deps:** update pnpm to v11.20.0 ([#69](https://github.com/GSTJ/safe-jsx/issues/69)) ([3bb5ce0](https://github.com/GSTJ/safe-jsx/commit/3bb5ce09f197d36c34924342b7580f0da967eb47))
+
 ## [1.3.7](https://github.com/GSTJ/safe-jsx/compare/v1.3.6...v1.3.7) (2026-08-04)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-safe-jsx",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "An ESLint plugin that enforces explicit boolean conversion before using && operator with JSX in React and React Native.",
   "keywords": [
     "boolean",


### PR DESCRIPTION
## Summary

This publishes the corrected Node engine metadata as v1.3.8.

## Details

- Bumps the package version to 1.3.8.
- Regenerates the changelog from the conventional commits since v1.3.7, including the engine fix and dependency maintenance.

## Testing steps

1. From the root of the checked-out repository, run:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run lint
   pnpm run format
   pnpm run typecheck
   pnpm run test
   pnpm run build
   pnpm run changelog:check
   pnpm audit --audit-level low
   npm pack
   ```

2. From the same directory, run:

   ```sh
   docker run --rm -v "$PWD:/package:ro" node:12-alpine sh -lc 'mkdir /app && cd /app && npm_config_engine_strict=true npm install /package/eslint-plugin-safe-jsx-1.3.8.tgz'
   ```

   The install should stop with an unsupported engine error.

3. Run:

   ```sh
   docker run --rm -v "$PWD:/package:ro" node:14-alpine sh -lc 'mkdir /app && cd /app && npm_config_engine_strict=true npm install --no-save /package/eslint-plugin-safe-jsx-1.3.8.tgz >/dev/null && node -e "console.log(require(\"eslint-plugin-safe-jsx\").meta)"'
   ```

   The command should print version 1.3.8.

4. Run:

   ```sh
   node tools/release-notes.mjs
   ```

   The first heading should be version 1.3.8 and list the engine fix.
