### PR TITLE
chore(deps): update magic tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci:
-    uses: GSTJ/magic/.github/workflows/ci.yml@4c640f094849d988c7380e1512f87c46a5408515 # v1.12.3
+    uses: GSTJ/magic/.github/workflows/ci.yml@918db02748a24375cc2c3e3e5fcaca5083e171b1 # v1.19.2
     with:
       node-version: "24"
       build-command: pnpm run build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,16 +41,16 @@ importers:
         version: 30.4.2(@types/node@26.1.2)(supports-color@8.1.1)
       magic-codemods:
         specifier: ^1.1.0
-        version: 1.1.1
+        version: 1.1.5
       magic-oxfmt-config:
         specifier: ^1.2.0
-        version: 1.2.1(oxfmt@0.62.0)
+        version: 1.2.5(oxfmt@0.62.0)
       magic-oxlint-config:
         specifier: ^2.0.0
-        version: 2.0.0(eslint@10.8.0(supports-color@8.1.1))(oxlint@1.77.0)
+        version: 2.0.4(eslint@10.8.0(supports-color@8.1.1))(oxlint@1.77.0)
       magic-tsconfig:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.4
       oxfmt:
         specifier: 0.62.0
         version: 0.62.0
@@ -1619,13 +1619,13 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-codemods@1.1.1:
-    resolution: {integrity: sha512-rFqykNef3SHlr8anVAYiDiIXqw9WNbJ+lsXoLyXGeWOiyUILQNm6csnB1SL92DQiuuyRU7YRHDHOW1+gW0M6ZA==}
+  magic-codemods@1.1.5:
+    resolution: {integrity: sha512-KszxXtjc4x0iuzlL84kSTlLMncJpQ5blRs8+H8iBO1vulYRegIdtAmwVxLUc195sO+i8o94Kbqszo6tpMDgsxQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  magic-oxfmt-config@1.2.1:
-    resolution: {integrity: sha512-LzvHZAjvEkQwO7iWR0aYDPGveuG5YSou4Vc3zi+eZvLY66IBMI+OtM7pPBY+ODF8zlzZBYLajTgfNB4FGZqZ6Q==}
+  magic-oxfmt-config@1.2.5:
+    resolution: {integrity: sha512-p13sB9X2aqXo78RsQT7j8wPI3omppkUb5Qmp0Ol99dldB1gzWHYeZazhGN29mv9ekephUyRIk5Wtsi/AgtwYFQ==}
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
@@ -1634,8 +1634,8 @@ packages:
       oxfmt:
         optional: true
 
-  magic-oxlint-config@2.0.0:
-    resolution: {integrity: sha512-4fyDWv8aWqK14ykjhbSn1xtkOcTlDY1NK3G9h6QaRrcepWZ9bQ89ZduqBc+ZyeE0aoogQvcjS9O9hSfn/6lXIQ==}
+  magic-oxlint-config@2.0.4:
+    resolution: {integrity: sha512-urPfrwREQJMIr8ap1dYEAb9XlJPYbypmSzf/2jmFW25CwiSRE6FEbLjW3FKmJEk8kB1UxLH/s7MUbiiaQ++X6w==}
     engines: {node: '>=22.18.0'}
     peerDependencies:
       oxlint: '>=1.75.0'
@@ -1643,8 +1643,8 @@ packages:
       oxlint:
         optional: true
 
-  magic-oxlint-plugin@1.2.0:
-    resolution: {integrity: sha512-aW8MpAp1uFdEn1xXcIcZR7cI5GE+P/EOjwzEhFi/r0CrFOdIyEVZK9JpmK+P53jmu7c0+x6NlOxS4AY464yqDw==}
+  magic-oxlint-plugin@1.2.4:
+    resolution: {integrity: sha512-kpli3A+pUg5JrR+PTPcCqrnqroGb6hkvINjtX/9xCxs1ceT7CugDdKsQRawsGKURxeHOuPPqyIjcDzbryE+EOg==}
     engines: {node: '>=22'}
     peerDependencies:
       oxlint: '>=1.75.0'
@@ -1652,8 +1652,8 @@ packages:
       oxlint:
         optional: true
 
-  magic-tsconfig@1.2.0:
-    resolution: {integrity: sha512-odQYUHWzEvgB85RsdRvKwYQPm4/zMMgXABhPPHyNpkEd4T4OqPp8SI4LfYQAn5LXLIktLHzqSJktH5g0Y5EeIQ==}
+  magic-tsconfig@1.2.4:
+    resolution: {integrity: sha512-wDcuTfxZ5OlA1dW8G8ijcyUxOCuuyXzyf3OcyV/6SPrmydkiDQIYGFgV+/VM2VqIdObdGuyMSzKM/KXJiWKJ0w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3803,28 +3803,28 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  magic-codemods@1.1.1:
+  magic-codemods@1.1.5:
     dependencies:
       ts-morph: 28.0.0
 
-  magic-oxfmt-config@1.2.1(oxfmt@0.62.0):
+  magic-oxfmt-config@1.2.5(oxfmt@0.62.0):
     optionalDependencies:
       oxfmt: 0.62.0
 
-  magic-oxlint-config@2.0.0(eslint@10.8.0(supports-color@8.1.1))(oxlint@1.77.0):
+  magic-oxlint-config@2.0.4(eslint@10.8.0(supports-color@8.1.1))(oxlint@1.77.0):
     dependencies:
       eslint-plugin-safe-jsx: 1.3.6(eslint@10.8.0(supports-color@8.1.1))
-      magic-oxlint-plugin: 1.2.0(oxlint@1.77.0)
+      magic-oxlint-plugin: 1.2.4(oxlint@1.77.0)
     optionalDependencies:
       oxlint: 1.77.0
     transitivePeerDependencies:
       - eslint
 
-  magic-oxlint-plugin@1.2.0(oxlint@1.77.0):
+  magic-oxlint-plugin@1.2.4(oxlint@1.77.0):
     optionalDependencies:
       oxlint: 1.77.0
 
-  magic-tsconfig@1.2.0: {}
+  magic-tsconfig@1.2.4: {}
 
   make-dir@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Updates the shared CI workflow to magic v1.19.2 and refreshes the first-party tooling locked for local checks.

## Details

- Pins the reusable CI workflow to the v1.19.2 commit.
- Refreshes `magic-codemods`, `magic-oxfmt-config`, `magic-oxlint-config`, and `magic-tsconfig` in the lockfile.

## Testing steps

1. From the root of the checked-out repository, run:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run lint
   pnpm run format
   pnpm run typecheck
   pnpm run test
   pnpm run build
   pnpm run changelog:check
   pnpm audit --audit-level low
   ```

2. Confirm every command exits successfully.
