### PR TITLE
ci: stop redundant greeting runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       # The changelog preset decides which commit types reach CHANGELOG.md, and
       # getting it wrong drops commits silently. This renders a synthetic
       # history through it and fails if a breaking change goes missing.
-      extra-command: pnpm run changelog:check
+      extra-command: pnpm run changelog:check && pnpm run workflow:check
       # Nothing in this repo uses turbo.
       turbo-cache: false

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,10 @@
 name: Greetings
 
-on: [pull_request_target, issues]
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
 
 jobs:
   greeting:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format:fix": "oxfmt .",
     "typecheck": "tsc --noEmit",
     "test": "jest --coverage",
+    "workflow:check": "node tools/greetings-workflow-check.mjs",
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "prepublishOnly": "safe-publish-latest && npm run lint && npm run test",
     "changelog": "node tools/changelog.mjs",

--- a/tools/greetings-workflow-check.mjs
+++ b/tools/greetings-workflow-check.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+
+const workflowPath = process.argv[2] ?? ".github/workflows/greetings.yml";
+const source = readFileSync(workflowPath, "utf8");
+const lines = source.split(/\r?\n/);
+const onIndex = lines.indexOf("on:");
+
+if (onIndex === -1) {
+  console.error(
+    'greetings workflow event contract FAILED: missing top-level "on" block',
+  );
+  process.exit(1);
+}
+
+/** @type {Record<string, string[]>} */
+const events = {};
+/** @type {string | undefined} */
+let currentEvent;
+
+for (const line of lines.slice(onIndex + 1)) {
+  if (line && !line.startsWith(" ")) break;
+
+  const eventMatch = /^  ([a-z_]+):\s*$/.exec(line);
+  const eventName = eventMatch?.[1];
+  if (eventName) {
+    currentEvent = eventName;
+    events[currentEvent] = [];
+  } else {
+    const typesMatch = /^    types:\s*\[([^\]]*)\]\s*$/.exec(line);
+    const typeList = typesMatch?.[1];
+    if (typeList !== undefined && currentEvent) {
+      events[currentEvent] = typeList
+        .split(",")
+        .map((type) => type.trim())
+        .filter(Boolean);
+    }
+  }
+}
+
+const expected = {
+  issues: ["opened"],
+  pull_request_target: ["opened"],
+};
+
+if (JSON.stringify(events) !== JSON.stringify(expected)) {
+  console.error("greetings workflow event contract FAILED");
+  console.error(`expected: ${JSON.stringify(expected)}`);
+  console.error(`received: ${JSON.stringify(events)}`);
+  process.exit(1);
+}
+
+console.log(
+  "greetings workflow event contract passed (issues=opened, pull_request_target=opened)",
+);


### PR DESCRIPTION
## Summary

The workflow now greets first-time contributors only when they open an issue or pull request.

## Details

- Renovate's dashboard edits no longer start no-op greeting runs.
- CI now checks that issue and pull request greetings accept only `opened` events.

## Testing steps

Run:

```sh
pnpm run workflow:check
```

The command should report that issue and pull request greetings run only for newly opened items.
