### PR TITLE
ci: keep the greeting check out of the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       # The changelog preset decides which commit types reach CHANGELOG.md, and
       # getting it wrong drops commits silently. This renders a synthetic
       # history through it and fails if a breaking change goes missing.
-      extra-command: pnpm run changelog:check && pnpm run workflow:check
+      extra-command: pnpm run changelog:check && node tools/greetings-workflow-check.mjs
       # Nothing in this repo uses turbo.
       turbo-cache: false

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "format:fix": "oxfmt .",
     "typecheck": "tsc --noEmit",
     "test": "jest --coverage",
-    "workflow:check": "node tools/greetings-workflow-check.mjs",
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "prepublishOnly": "safe-publish-latest && npm run lint && npm run test",
     "changelog": "node tools/changelog.mjs",


### PR DESCRIPTION
## Summary

The greeting contract check now runs directly in CI without adding a broken script to the published package.

## Details

- The package excludes maintenance tools, so its script could not resolve after install.
- CI still runs the check by calling the checker directly.

## Testing steps

Run:

```sh
node tools/greetings-workflow-check.mjs
npm pack --dry-run
```

The first command should confirm both greeting triggers are restricted to newly opened items. The tarball preview should include seven files and no maintenance tools.
